### PR TITLE
Remove container after running. Use Domain which does not redirect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Apache Benchmark Docker image
 Run
 ---
 
-	$ docker run jordi/ab ab -v 2 https://docker.io/
+	$ docker run --rm jordi/ab ab -v 2 https://www.docker.com/
 
 
 Pull


### PR DESCRIPTION
Hey, thanks for this image!

I think its best practice to remove one-time containers after running so I reflected that in the sample call.

Moreover I switched to a URL returning HTTP 200 instead of 301 just for beauty.
