### PR TITLE
Add a volume for attachments to be able to send files to the server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ MAINTAINER Jordi Íñigo Griera
 ENV TERM linux
 RUN apk --no-cache add apache2-utils
 
+VOLUME ["/attachments"]
+
 CMD ["/usr/bin/ab"]


### PR DESCRIPTION
This PR adds a volume to be able to use Apache Bench's -p arg:
```-p postfile     File containing data to POST. Remember also to set -T```